### PR TITLE
Make the Keypather class auto-instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install keypather
 dot notation, bracket notation, and functions (even with arguments) all supported:
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: {
     bar: {
@@ -28,7 +28,7 @@ keypath.get(obj, "['foo']['bar']['baz']"); // val
 ```
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: function () {
     return function () {
@@ -42,7 +42,7 @@ keypath.get(obj, "foo()()()"); // val
 ```
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: function () {
     return {
@@ -56,7 +56,7 @@ keypath.get(obj, "foo()['bar'].baz"); // val
 ```
 functions with arguments
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   create: function (data) {
     var data = data;
@@ -77,7 +77,7 @@ Get returns null for keypaths that do not exist by default,
 but can also throw errors with `{ force: false }`
 
 ```js
-var keypath = require('keypather')(); // equivalent to { force:true }
+var keypath = require('keypather'); // equivalent to { force:true }
 var obj = {};
 keypath.get(obj, "foo.bar.baz"); // null
 
@@ -93,7 +93,7 @@ keypath.get(obj, "foo.bar.baz");
 mixed notation, dot notation, and bracket notation all supported:
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: {
       bar: {
@@ -110,7 +110,7 @@ keypath.set(obj, "['foo']['bar']['baz']", 'value'); // value
  Set forces creation by default:
 
 ```js
-var keypath = require('keypather')(); // equivalent to { force:true }
+var keypath = require('keypather'); // equivalent to { force:true }
 var obj = {};
 keypath.set(obj, "foo.bar.baz", 'val'); // value
 // obj = {
@@ -133,7 +133,7 @@ keypath.set(obj, "foo.bar.baz", 'val');
 Equivalent to `key in obj`
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: {
       bar: {
@@ -159,7 +159,7 @@ keypath.in(obj, "['foo']['bar']['baz']"); // true
 Equivalent to `obj.hasOwnProperty`
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: {
       bar: {
@@ -185,7 +185,7 @@ keypath.has(obj, "['foo']['bar']['baz']"); // true
 Equivalent to `delete obj.key`
 
 ```js
-var keypath = require('keypather')();
+var keypath = require('keypather');
 var obj = {
   foo: {
       bar: {

--- a/index.js
+++ b/index.js
@@ -5,10 +5,8 @@ function factoryAndInstance (opts) {
 };
 Keypather.call(factoryAndInstance);
 factoryAndInstance.__proto__ = new Keypather().__proto__;
-
-function Keypather (opts) {
-  if (!(this instanceof Keypather)) { return new Keypather(opts); }// Auto instantiate
-  this.force = (opts && typeof opts.force !== 'undefined' && Boolean(opts.force) === false ? false : true);
+function Keypather (force) {
+  this.force = (force !== undefined) ? Boolean(force) : true; // force - default: true
 }
 Keypather.prototype.get = function (/* obj, keypath, fnArgs... */) {
   this.create = false;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
-var keypather = module.exports = function (opts) {
-  var keypather = new Keypather(opts && opts.force);
-  return keypather;
-};
+module.exports = Keypather;
 
-function Keypather (force) {
-  this.force = (force !== undefined) ? Boolean(force) : true; // force - default: true
+function Keypather (opts) {
+  if (!(this instanceof Keypather)) { return new Keypather(opts); }// Auto instantiate
+  this.force = (opts && opts.force && Boolean(opts.force) === false || true); // force - default: true
 }
 Keypather.prototype.get = function (/* obj, keypath, fnArgs... */) {
   this.create = false;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
-module.exports = Keypather;
+module.exports = factoryAndInstance;
+function factoryAndInstance (opts) {
+  var keypather = new Keypather(opts && opts.force);
+  return keypather;
+};
+Keypather.call(factoryAndInstance);
+factoryAndInstance.__proto__ = new Keypather().__proto__;
 
 function Keypather (opts) {
   if (!(this instanceof Keypather)) { return new Keypather(opts); }// Auto instantiate
-  this.force = (opts && opts.force && Boolean(opts.force) === false ? false : true); // force - default: true
+  this.force = (opts && typeof opts.force !== 'undefined' && Boolean(opts.force) === false ? false : true);
 }
 Keypather.prototype.get = function (/* obj, keypath, fnArgs... */) {
   this.create = false;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = Keypather;
 
 function Keypather (opts) {
   if (!(this instanceof Keypather)) { return new Keypather(opts); }// Auto instantiate
-  this.force = (opts && opts.force && Boolean(opts.force) === false || true); // force - default: true
+  this.force = (opts && opts.force && Boolean(opts.force) === false ? false : true); // force - default: true
 }
 Keypather.prototype.get = function (/* obj, keypath, fnArgs... */) {
   this.create = false;

--- a/test/force.js
+++ b/test/force.js
@@ -44,10 +44,9 @@ function errorGetSet (keypath, value) {
       var tt, errs = [];
       try {
         tt = this.keypather.get(this.obj, keypath);
-        throw new Error("BLAH" + tt)
       }
       catch (err) {
-        console.error("ERR", tt)
+        console.error("ERR", err)
         errs.push(err);
       }
       console.error("AFTER-GET", tt)

--- a/test/force.js
+++ b/test/force.js
@@ -41,13 +41,17 @@ function errorGetSet (keypath, value) {
       this.keypather = keypather({ force: false });
     });
     it('should set the value', function () {
-      var errs = [];
+      var tt, errs = [];
       try {
-        this.keypather.get(this.obj, keypath);
+        tt = this.keypather.get(this.obj, keypath);
+        throw new Error("BLAH" + tt)
       }
       catch (err) {
+        console.error("ERR", tt)
         errs.push(err);
       }
+      console.error("AFTER-GET", tt)
+      errs.length.should.equal(1);
       try {
         this.keypather.set(this.obj, keypath, value);
       }


### PR DESCRIPTION
Hey @tjmehta I love your code's approach & scope of feature support... Anyway I will create a separate  issue to discuss some of my thoughts. Anyway, here's a patch to eliminate the need for double parenthesis:
See my updates to the README.md

